### PR TITLE
Add indexing scripts for Datastore and RAG engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Common tasks are available through the `Makefile`:
 make run        # run the deployed agent in the terminal
 make deploy     # deploy the agent to Vertex AI Agent Engine
 make rag-engine # create a RAG Engine corpus from local markdown files
+python scripts/index_datastore.py --metadata-file metadata.json \ 
+    # index markdown and metadata into Cloud Datastore
+python scripts/index_rag_engine.py --metadata-file metadata.json \ 
+    --corpus your-corpus-id  # upload files to an existing RAG corpus
 ```
 
 The deployment script writes the created agent engine id to `.env`. Ensure this file contains your Vertex project credentials before running the make commands.

--- a/scripts/index_datastore.py
+++ b/scripts/index_datastore.py
@@ -1,0 +1,62 @@
+"""Index Markdown documents with metadata into Google Cloud Datastore."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List, Dict, Any
+
+from dotenv import load_dotenv
+from google.cloud import datastore
+
+
+def load_entries(md_dir: Path, metadata_file: Path) -> List[Dict[str, Any]]:
+    """Load markdown content and metadata."""
+    with metadata_file.open("r", encoding="utf-8") as f:
+        items = json.load(f)
+
+    entries: List[Dict[str, Any]] = []
+    for item in items:
+        file_path = md_dir / item["filename"]
+        with file_path.open("r", encoding="utf-8") as f:
+            content = f.read()
+        entries.append(
+            {
+                "id": item["filename"],
+                "content": content,
+                "metadata": item.get("metadata", {}),
+            }
+        )
+    return entries
+
+
+def index_to_datastore(project: str, kind: str, entries: List[Dict[str, Any]]) -> None:
+    """Write the entries to Datastore."""
+    client = datastore.Client(project=project)
+    for entry in entries:
+        key = client.key(kind, entry["id"])
+        entity = datastore.Entity(key=key)
+        entity["content"] = entry["content"]
+        for k, v in entry["metadata"].items():
+            entity[k] = v
+        client.put(entity)
+    print(f"Indexed {len(entries)} documents to Datastore kind '{kind}'")
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Index markdown files into Datastore")
+    parser.add_argument("--markdown-dir", type=Path, default=Path("docs"), help="Directory containing markdown files")
+    parser.add_argument("--metadata-file", type=Path, required=True, help="JSON file with metadata")
+    parser.add_argument("--project", default=os.getenv("GOOGLE_CLOUD_PROJECT"), help="GCP project id")
+    parser.add_argument("--kind", default=os.getenv("DATASTORE_KIND", "Document"), help="Datastore kind")
+    args = parser.parse_args()
+
+    entries = load_entries(args.markdown_dir, args.metadata_file)
+    if not args.project:
+        raise ValueError("GCP project must be specified via --project or environment variable")
+    index_to_datastore(args.project, args.kind, entries)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/index_rag_engine.py
+++ b/scripts/index_rag_engine.py
@@ -1,0 +1,66 @@
+"""Upload markdown documents with metadata to a Vertex AI RAG Engine corpus."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List, Dict, Any
+
+from dotenv import load_dotenv
+import vertexai
+from vertexai.preview import rag
+
+
+def load_entries(md_dir: Path, metadata_file: Path) -> List[Dict[str, Any]]:
+    """Load file paths and metadata."""
+    with metadata_file.open("r", encoding="utf-8") as f:
+        items = json.load(f)
+
+    entries: List[Dict[str, Any]] = []
+    for item in items:
+        file_path = md_dir / item["filename"]
+        entries.append(
+            {
+                "path": file_path,
+                "display_name": item["filename"],
+                "metadata": item.get("metadata", {}),
+            }
+        )
+    return entries
+
+
+def upload_to_rag(corpus: str, project: str, location: str, entries: List[Dict[str, Any]]) -> None:
+    """Upload the files to an existing RAG corpus."""
+    vertexai.init(project=project, location=location)
+    for entry in entries:
+        description = json.dumps(entry["metadata"])
+        rag.upload_file(
+            corpus_name=corpus,
+            path=str(entry["path"]),
+            display_name=entry["display_name"],
+            description=description,
+        )
+    print(f"Uploaded {len(entries)} files to corpus '{corpus}'")
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Upload markdown files to a RAG corpus")
+    parser.add_argument("--markdown-dir", type=Path, default=Path("docs"), help="Directory with markdown files")
+    parser.add_argument("--metadata-file", type=Path, required=True, help="JSON file with metadata")
+    parser.add_argument("--corpus", default=os.getenv("RAG_CORPUS"), help="RAG corpus name")
+    parser.add_argument("--project", default=os.getenv("GOOGLE_CLOUD_PROJECT"), help="GCP project id")
+    parser.add_argument("--location", default=os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1"), help="GCP region")
+    args = parser.parse_args()
+
+    if not args.corpus:
+        raise ValueError("RAG corpus must be specified via --corpus or environment variable")
+    if not args.project:
+        raise ValueError("GCP project must be specified via --project or environment variable")
+
+    entries = load_entries(args.markdown_dir, args.metadata_file)
+    upload_to_rag(args.corpus, args.project, args.location, entries)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create script to index markdown docs with metadata into Cloud Datastore
- create script to upload markdown docs with metadata to an existing Vertex AI RAG corpus
- document usage of new scripts in README

## Testing
- `python -m py_compile scripts/index_datastore.py scripts/index_rag_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6849910b0ce88332bb18ab54eda6c155